### PR TITLE
New release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @driver-digital/vite-plugin-shopify-clean
 
+## 1.0.1 - 2025-09-23 - Cleanup robustness and build-time cleaning
+
+- Handle ENOENT during deletions to prevent crashes when files are already removed (race-safe) in `buildStart()` and `writeBundle()`.
+- Run cleanup during production `vite build` (non-watch mode) to remove outdated hashed assets, not just during dev.
+- Add warnings for non-ENOENT deletion errors instead of failing the build.
+
 ## 1.0.0 - 2025-09-22 - Initial Release
 
 - Forked from [@by-association-only/vite-plugin-shopify-clean](https://github.com/dan-gamble/vite-plugin-shopify-clean)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@driver-digital/vite-plugin-shopify-clean",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Vite plugin for correctly cleaning up an assets folder",
   "private": false,
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,15 @@ export default function shopifyClean (options: VitePluginShopifyCleanOptions = {
         const location = path.join(assetsDir, base)
 
         if (existsSync(location)) {
-          return fs.unlink(location)
+          try {
+            await fs.unlink(location)
+          } catch (err: any) {
+            // Ignore files that no longer exist; they may have been removed by another process
+            if (err && err.code !== 'ENOENT') {
+              console.warn(`WARNING: Failed to delete asset ${location}: ${err.message ?? err}`)
+            }
+          }
+          return
         }
 
         return Promise.resolve()
@@ -62,8 +70,7 @@ export default function shopifyClean (options: VitePluginShopifyCleanOptions = {
 
     writeBundle: async function (_, bundle) {
       if (!(resolvedOptions.manifestFileName in bundle)) return
-      if (!this.meta.watchMode) return
-      if (writeBundleFirstRun) {
+      if (this.meta.watchMode && writeBundleFirstRun) {
         writeBundleFirstRun = false
 
         return
@@ -106,7 +113,15 @@ export default function shopifyClean (options: VitePluginShopifyCleanOptions = {
         const location = path.join(assetsDir, file)
 
         if (existsSync(location)) {
-          return fs.unlink(location)
+          try {
+            await fs.unlink(location)
+          } catch (err: any) {
+            // Ignore files that no longer exist; they may have been removed by another process
+            if (err && err.code !== 'ENOENT') {
+              console.warn(`WARNING: Failed to delete asset ${location}: ${err.message ?? err}`)
+            }
+          }
+          return
         }
 
         return Promise.resolve()


### PR DESCRIPTION
This pull request improves the robustness and reliability of the `@driver-digital/vite-plugin-shopify-clean` plugin, especially around asset cleanup during both development and production builds. The main changes ensure that file deletions are race-safe, prevent crashes if files are already deleted, and extend cleanup behavior to production builds. Documentation and usage instructions have also been updated for clarity.

**Robustness and Error Handling Improvements:**
* File deletions in both `buildStart()` and `writeBundle()` now ignore `ENOENT` (file-not-found) errors, preventing crashes if files are already removed by another process. Other deletion errors are logged as warnings instead of causing the build to fail. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L56-R64) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L109-R124)
* The documentation now explicitly states that deletions are resilient to ENOENT errors.
* The changelog documents these robustness improvements.

**Cleanup Behavior Enhancements:**
* Cleanup of outdated hashed assets now runs during production (`vite build`) as well as in development (watch mode), ensuring only current hashed files remain after any build. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L65-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R87) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8)

**Documentation and Usage Updates:**
* Updated `README.md` to clarify that cleanup occurs after each build output in both dev and production, and improved the usage example to use `shopifyClean` as the import name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R10) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R87)

**Package Metadata:**
* Bumped package version to `1.0.1` and added a `publishConfig` section for public publishing.