### PR TITLE
Add Phase 3 PR-first rail caller stubs

### DIFF
--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -1,0 +1,32 @@
+name: Dependabot report
+
+# CALLER STUB — install into a pipeline repo's .github/workflows/.
+# Calls the central PRIVILEGED report reusable on `workflow_run` (after the
+# 'Dependabot validate' workflow completes). Passes the triggering-run context
+# explicitly (a reusable cannot see github.event.workflow_run) + inherits secrets.
+
+on:
+  workflow_run:
+    workflows: ["Dependabot validate"] # MUST equal the validate stub's `name:` exactly
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: dependabot-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    # Pinned to DriverDigital/workflows v1.0.0
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    with:
+      triggering-run-id: ${{ github.event.workflow_run.id }}
+      head-repository: ${{ github.event.workflow_run.head_repository.full_name }}
+      pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      validate-conclusion: ${{ github.event.workflow_run.conclusion }}
+      workflow-event: ${{ github.event.workflow_run.event }}
+      triggering-actor: ${{ github.event.workflow_run.actor.login }}
+    secrets: inherit

--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -20,8 +20,8 @@ concurrency:
 
 jobs:
   report:
-    # Pinned to DriverDigital/workflows v1.0.0
-    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    # Pinned to DriverDigital/workflows v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
     with:
       triggering-run-id: ${{ github.event.workflow_run.id }}
       head-repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,0 +1,26 @@
+name: Dependabot validate
+
+# CALLER STUB — install into a pipeline repo's .github/workflows/.
+# Calls the central UNPRIVILEGED validate reusable. Carries NO secrets — keep it
+# credential-less (it runs untrusted Dependabot build).
+#
+# ⚠️ The `name:` above MUST stay byte-identical (`Dependabot validate`) across every
+# pipeline repo — the `dependabot-report` stub's `workflow_run` trigger name-matches
+# it exactly; a drift silently disables the human-ping.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-validate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    # Pinned to DriverDigital/workflows v1.0.0
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -21,6 +21,6 @@ concurrency:
 
 jobs:
   validate:
-    # Pinned to DriverDigital/workflows v1.0.0
-    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    # Pinned to DriverDigital/workflows v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
     # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -1,0 +1,25 @@
+name: PR-first review
+
+# CALLER STUB — install into a pipeline repo's .github/workflows/.
+# Calls the central pr-first-review reusable on human, no-ticket PRs. Inherits
+# secrets (safe: fork PRs get none under `pull_request`, and the reusable also
+# guards to same-repo PRs).
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened] # NOT synchronize — review once, re-trigger on demand
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: pr-first-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Pinned to DriverDigital/workflows v1.0.0
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    secrets: inherit

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -20,6 +20,6 @@ concurrency:
 
 jobs:
   review:
-    # Pinned to DriverDigital/workflows v1.0.0
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@f52a2d2d1051f9de178aad498e0691b3d9f09be8
+    # Pinned to DriverDigital/workflows v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
     secrets: inherit


### PR DESCRIPTION
Installs the Phase 3 PR-first rail caller stubs, pinned to `DriverDigital/workflows@v1.0.0` (`f52a2d2`):

- **pr-first-review.yml** — human, no-ticket PRs → `/code-review` (comments) + request a reviewer
- **dependabot-validate.yml** — mechanical build validation (runs on every PR; no-ops green on non-Dependabot, so it can be a required check)
- **dependabot-report.yml** — privileged verdict + reviewer request on Dependabot PRs (provenance-gated)

Merging activates the rail — `pull_request` workflows run from the base branch, so **this PR does not self-trigger them**. After merge, a human test PR exercises pr-first-review + the validate no-op + report's provenance-skip. Testing the real Dependabot validation path needs Dependabot enabled (`.github/dependabot.yml`) — separate.

After the first run, pin the required check `validate / validate` in branch protection + add a human-approver rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow to validate Dependabot updates on pull requests.
  * Added a follow-up GitHub Actions workflow to generate and publish Dependabot report results after validation completes.
  * Added an automated “first review” GitHub Actions workflow for newly opened pull requests to streamline review setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->