### PR TITLE
Let Dependabot track + auto-bump the PR-first rail reusable pin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,6 @@ updates:
   # Keep GitHub Actions dependencies up to date
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "develop"
     schedule:
       interval: "monthly"
     # Raise all GitHub Actions pull requests with assignees

--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   report:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
     with:
       triggering-run-id: ${{ github.event.workflow_run.id }}
       head-repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -20,8 +20,7 @@ concurrency:
 
 jobs:
   report:
-    # Pinned to DriverDigital/workflows v1.0.1
-    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
     with:
       triggering-run-id: ${{ github.event.workflow_run.id }}
       head-repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -21,6 +21,5 @@ concurrency:
 
 jobs:
   validate:
-    # Pinned to DriverDigital/workflows v1.0.1
-    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
     # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -21,5 +21,5 @@ concurrency:
 
 jobs:
   validate:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
     # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -20,5 +20,5 @@ concurrency:
 
 jobs:
   review:
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
     secrets: inherit

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -20,6 +20,5 @@ concurrency:
 
 jobs:
   review:
-    # Pinned to DriverDigital/workflows v1.0.1
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@627c2ddbb2f4f2201c70c87f39a72bcacfbe585b # v1.0.1
     secrets: inherit


### PR DESCRIPTION
Makes the consumer side of the rail auto-bump when we cut a new `DriverDigital/workflows` tag.

## Two changes
1. **Inline version comment on the 3 caller stubs** — `uses: …@<sha> # v1.0.1`. Dependabot reads the tracked version from an *inline* trailing comment, not the separate `# Pinned to …` line we had above `uses:`.
2. **Point the `github-actions` Dependabot at `main`** (removed its `target-branch: develop`). The rail stubs live on `main`, so the actions Dependabot has to scan `main` to see them. **npm Dependabot is left on `develop`, unchanged** — happy to migrate that separately as part of moving off `develop`.

## Effect
When we ship a new reusable tag (e.g. v1.0.2), Dependabot opens a **reviewed** PR here bumping the pin. (Reusable-pin bumps are *not* auto-merged — they change which rail logic runs, so a human looks. The central repo separately auto-merges only its low-risk GitHub-owned action bumps.)

No behavior change to the rail itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow dependencies to newer stable versions for improved reliability and consistency across automated processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->