### PR TITLE
Bring PR-first rail to v1.1.1 + draft guard

### DIFF
--- a/.github/workflows/dependabot-keep-current.yml
+++ b/.github/workflows/dependabot-keep-current.yml
@@ -1,0 +1,23 @@
+name: Dependabot keep current
+
+# CALLER STUB — install into a pipeline repo's .github/workflows/.
+# Rebases open Dependabot PRs that are BLOCKED by being out of date when a merge
+# lands on their base branch (retires the manual `@dependabot rebase`). Only acts
+# on strict (require-up-to-date) repos; inert where behind PRs merge fine.
+# Branch-agnostic: the reusable scopes to the merged PR's base, so one stub covers
+# main/develop/staging. (Closed-but-unmerged PRs produce a skipped run by design.)
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  keep-current:
+    # Pinned to DriverDigital/workflows v1.1.1
+    uses: DriverDigital/workflows/.github/workflows/dependabot-keep-current.yml@9d0a595009ed88e737668e7a58a79891b842dfeb # v1.1.1
+    secrets:
+      AGENTS_GH_PAT: ${{ secrets.AGENTS_GH_PAT }}

--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   report:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@9d0a595009ed88e737668e7a58a79891b842dfeb # v1.1.1
     with:
       triggering-run-id: ${{ github.event.workflow_run.id }}
       head-repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -21,5 +21,5 @@ concurrency:
 
 jobs:
   validate:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@9d0a595009ed88e737668e7a58a79891b842dfeb # v1.1.1
     # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -20,5 +20,8 @@ concurrency:
 
 jobs:
   review:
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@bfcafe2fef3934263fbd7751c18b07453f3a798f # v1.0.2
+    # Only review real, published PRs — skip drafts (many repos open a draft PR first for build-test CI).
+    # `ready_for_review` (in the trigger list above) covers the draft→ready transition.
+    if: ${{ github.event.pull_request.draft == false }}
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@9d0a595009ed88e737668e7a58a79891b842dfeb # v1.1.1
     secrets: inherit


### PR DESCRIPTION
Maintenance: repin the pilot's rail stubs v1.0.2 → v1.1.1 and add the draft guard (skip `/code-review` on draft PRs), matching the fleet rollout. Also adds the `dependabot-keep-current` stub (inert on this non-strict repo) so the pilot carries the full kit. No behavior change beyond skipping drafts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automation workflow for keeping dependencies current
  * Updated CI/CD workflows to latest versions
  * Enhanced PR review process to better handle draft pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->