### PR TITLE
[TEST · DO NOT MERGE] v1.4.0 PR-first — errored run (expect ⚠️ + red check)

### DIFF
--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -23,5 +23,5 @@ jobs:
     # Only review real, published PRs — skip drafts (many repos open a draft PR first for build-test CI).
     # `ready_for_review` (in the trigger list above) covers the draft→ready transition.
     if: ${{ github.event.pull_request.draft == false }}
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@b1e0cdcc6d15d4eeb075a4bb50d2e4b330baf657 # v1.4.0
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@5bd3a36e1c591166a7fee50b609716fb7b4552aa # [TEST] forced --max-turns 1 error-injection
     secrets: inherit

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { Manifest, Plugin } from 'vite'
 
 import { resolveOptions, VitePluginShopifyCleanOptions } from './options'
 
+/** Type guard: narrows an unknown thrown value to a Node.js system error (one carrying a `code`). */
 function isNodeError (err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && 'code' in err
 }


### PR DESCRIPTION
**Test PR — please don't merge; I'll close it after you've looked.**

Validates the **errored** branch of the new outcome-aware marker. The stub here is pinned to a throwaway central branch (`test/force-error-max-turns` = v1.4.0 + `--max-turns 1`), which forces the `/code-review` step to hit `error_max_turns` and **fail**. The marker runs anyway (`!cancelled()`) and should post:

> 🤖 Automated PR-first review — ⚠️ **this review did not complete.** It errored or hit a limit before finishing, so this PR is effectively **unreviewed** … Run log: …

What to check once the `review / review` check finishes:
- the `review / review` check is **RED** (the review step genuinely failed)
- the marker comment is the **⚠️ "did not complete / effectively unreviewed"** warning with a run-log link — NOT a false "all clear"

This is the safety property you flagged: a broken review can no longer masquerade as clean. (The real fleet pins to v1.4.0 `b1e0cdc` with no turn cap — this `--max-turns 1` branch exists only to force the failure for this test, and I'll delete it after.)