### PR TITLE
fix(ticketed-review): declare explicit permissions in caller stub

### DIFF
--- a/.github/workflows/ticketed-review.yml
+++ b/.github/workflows/ticketed-review.yml
@@ -18,6 +18,16 @@ concurrency:
   group: ticketed-review-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
+# Least-privilege token for the reusable's GitHub ops — declared explicitly here, NOT inherited.
+# Without this block a repo whose default workflow-token permission is "read" caps pull-requests and
+# issues at none, so the reusable's `pull-requests: write` request exceeds the ceiling and the whole
+# run fails workflow validation → a SILENT startup_failure (no check run, no notification). Mirrors
+# pr-first-review.yml, which has always carried it.
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
 jobs:
   review:
     # round 1: a claude[bot] PR; OR the re-review sentinel — which is posted ONLY by


### PR DESCRIPTION
## What
Adds the top-level `permissions:` block to this repo's `ticketed-review.yml` caller stub (mirroring `pr-first-review.yml`). The pinned reusable ref is unchanged.

## Why
The stub omitted an explicit `permissions:` block, so it inherited the repo default workflow-token permission. On a repo whose default is `read`, that caps `pull-requests`/`issues` at `none`; the reusable's `pull-requests: write` request then exceeds the ceiling and the run fails workflow validation as a **silent `startup_failure`** — no check run, no notification. This repo is on the `write` default, so the rail works today; this block makes it immune regardless of the setting (defense in depth).

## Scope
CI only. No behavior change while the repo default stays `write`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an automated review workflow to use explicit least-privilege access permissions.
  * Improves reliability of pull request operations in environments with stricter default token settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->