### PR TITLE
chore: repin central workflows to v1.5.5 (uniform fleet wave)

### DIFF
--- a/.github/workflows/dependabot-keep-current.yml
+++ b/.github/workflows/dependabot-keep-current.yml
@@ -18,6 +18,6 @@ permissions:
 jobs:
   keep-current:
     # Pinned to DriverDigital/workflows v1.1.1
-    uses: DriverDigital/workflows/.github/workflows/dependabot-keep-current.yml@34826c98f47b72723b394ee5256e37ef605a1973 # v1.5.4
+    uses: DriverDigital/workflows/.github/workflows/dependabot-keep-current.yml@0b1a657ba6db038ae0bfa845dff758709f0567ab # v1.5.5
     secrets:
       AGENTS_GH_PAT: ${{ secrets.AGENTS_GH_PAT }}

--- a/.github/workflows/dependabot-report.yml
+++ b/.github/workflows/dependabot-report.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   report:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@34826c98f47b72723b394ee5256e37ef605a1973 # v1.5.4
+    uses: DriverDigital/workflows/.github/workflows/dependabot-report.yml@0b1a657ba6db038ae0bfa845dff758709f0567ab # v1.5.5
     with:
       triggering-run-id: ${{ github.event.workflow_run.id }}
       head-repository: ${{ github.event.workflow_run.head_repository.full_name }}

--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -21,5 +21,5 @@ concurrency:
 
 jobs:
   validate:
-    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@34826c98f47b72723b394ee5256e37ef605a1973 # v1.5.4
+    uses: DriverDigital/workflows/.github/workflows/dependabot-validate.yml@0b1a657ba6db038ae0bfa845dff758709f0567ab # v1.5.5
     # NO `secrets:` line — intentional and load-bearing. Do not add one.

--- a/.github/workflows/pr-first-review.yml
+++ b/.github/workflows/pr-first-review.yml
@@ -23,5 +23,5 @@ jobs:
     # Only review real, published PRs — skip drafts (many repos open a draft PR first for build-test CI).
     # `ready_for_review` (in the trigger list above) covers the draft→ready transition.
     if: ${{ github.event.pull_request.draft == false }}
-    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@34826c98f47b72723b394ee5256e37ef605a1973 # v1.5.4
+    uses: DriverDigital/workflows/.github/workflows/pr-first-review.yml@0b1a657ba6db038ae0bfa845dff758709f0567ab # v1.5.5
     secrets: inherit

--- a/.github/workflows/ticketed-review.yml
+++ b/.github/workflows/ticketed-review.yml
@@ -40,7 +40,7 @@ jobs:
        contains(github.event.comment.body, '<!-- request-ticketed-review -->') &&
        github.event.comment.user.login == 'driver-digital-agents' &&
        github.event.comment.user.id == 261291955)
-    uses: DriverDigital/workflows/.github/workflows/ticketed-review.yml@34826c98f47b72723b394ee5256e37ef605a1973 # v1.5.4
+    uses: DriverDigital/workflows/.github/workflows/ticketed-review.yml@0b1a657ba6db038ae0bfa845dff758709f0567ab # v1.5.5
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
     secrets:


### PR DESCRIPTION
Fleet-wide uniform repin to DriverDigital/workflows v1.5.5 (0b1a657 — claude-code-action 1.0.161→1.0.168 in the agent reusables; also picks up v1.5.4's dependabot-validate npm-install fallback for stubs still on older pins). Audit: workflows repo tools/fleet-pin-audit.sh.