### PR TITLE
Pilot: bonsai-status-sync v1.11.0 variable-resolution assertion

### DIFF
--- a/.pilot-bonsai-v1110
+++ b/.pilot-bonsai-v1110
@@ -1,0 +1,1 @@
+v1.11.0 pilot marker. Safe to delete.


### PR DESCRIPTION
Closes #82

Asserts that `vars.BONSAI_URL` resolves against the CALLER repo now that bonsai-status-sync is a cross-repo reusable.

The repo variable is temporarily set to a bogus host. A red run naming that host proves caller resolution. A run naming the hardcoded default would mean the variable resolved against DriverDigital/workflows, where it does not exist — which would mean the documented per-repo tunnel override is silently dead fleet-wide.

Cleaned up either way.